### PR TITLE
Defensive code for connection error handling and userId lookup.

### DIFF
--- a/lib/Bot.cs
+++ b/lib/Bot.cs
@@ -51,8 +51,7 @@ namespace Slackbot
 
         async void Connect()
         {
-            var url = await Slack.GetWebsocketUrl(this.Token);
-            SocketConnection = new SocketConnection(url);
+            SocketConnection = new SocketConnection(async () => await Slack.GetWebsocketUrl(this.Token));
 
             SocketConnection.OnData += (sender, data) =>
             {

--- a/lib/Slack.cs
+++ b/lib/Slack.cs
@@ -43,7 +43,7 @@ namespace Slackbot
                     .Json
                     .JsonConvert
                     .DeserializeObject<SlackUserList>(responseContent)
-                    .Members.First(member => member.Id == userId).Name;
+                    .Members.First(member => member.Id == userId.Split('|')[0])?.Name ?? "";
             }
         }
     }

--- a/lib/Slackbot.csproj
+++ b/lib/Slackbot.csproj
@@ -6,6 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/lib/SocketConnection.cs
+++ b/lib/SocketConnection.cs
@@ -11,8 +11,6 @@ namespace Slackbot
         public readonly string Url;
         public event EventHandler<string> OnData;
         private ClientWebSocket Socket;
-        private int maxRetryCount = 4;
-        private int secondsBetweenRetry = 2;
 
         public SocketConnection(string url)
         {
@@ -27,12 +25,10 @@ namespace Slackbot
 
         async void Connect()
         {
-            await TryConnect();
-        }
-
-        private async System.Threading.Tasks.Task TryConnect()
-        {
+            int maxRetryCount = 4;
+            int secondsBetweenRetry = 2;
             int retryCounter = 0;
+
             while (retryCounter < maxRetryCount)
             {
                 try
@@ -75,6 +71,7 @@ namespace Slackbot
                     else
                     {
                         Thread.Sleep(sleepTimeSeconds * 1000);
+                        Connect();
                     }
                 }
             }

--- a/lib/SocketConnection.cs
+++ b/lib/SocketConnection.cs
@@ -11,6 +11,8 @@ namespace Slackbot
         public readonly string Url;
         public event EventHandler<string> OnData;
         private ClientWebSocket Socket;
+        private int maxRetryCount = 4;
+        private int secondsBetweenRetry = 2;
 
         public SocketConnection(string url)
         {
@@ -25,10 +27,12 @@ namespace Slackbot
 
         async void Connect()
         {
-            int maxRetryCount = 4;
-            int secondsBetweenRetry = 2;
-            int retryCounter = 0;
+            await TryConnect();
+        }
 
+        private async System.Threading.Tasks.Task TryConnect()
+        {
+            int retryCounter = 0;
             while (retryCounter < maxRetryCount)
             {
                 try
@@ -71,7 +75,6 @@ namespace Slackbot
                     else
                     {
                         Thread.Sleep(sleepTimeSeconds * 1000);
-                        Connect();
                     }
                 }
             }

--- a/lib/SocketConnection.cs
+++ b/lib/SocketConnection.cs
@@ -67,12 +67,9 @@ namespace Slackbot
                     int sleepTimeSeconds = Convert.ToInt32(Math.Pow(secondsBetweenRetry, retryCounter + 1));
                     retryCounter++;
 
-                    Console.WriteLine($"Exception connecting to Slack: {Environment.NewLine} {e.ToString()}");
-                    Console.WriteLine();
-                    Console.WriteLine($"Sleeping for {sleepTimeSeconds} seconds before retry...");
-
                     if (retryCounter >= maxRetryCount)
                     {
+                        Console.WriteLine($"FATAL exception connecting to Slack: {Environment.NewLine} {e.ToString()}");
                         throw e;
                     }
                     else

--- a/lib/SocketConnection.cs
+++ b/lib/SocketConnection.cs
@@ -67,9 +67,12 @@ namespace Slackbot
                     int sleepTimeSeconds = Convert.ToInt32(Math.Pow(secondsBetweenRetry, retryCounter + 1));
                     retryCounter++;
 
+                    Console.WriteLine($"Exception connecting to Slack: {Environment.NewLine} {e.ToString()}");
+                    Console.WriteLine();
+                    Console.WriteLine($"Sleeping for {sleepTimeSeconds} seconds before retry...");
+
                     if (retryCounter >= maxRetryCount)
                     {
-                        Console.WriteLine($"FATAL exception connecting to Slack: {Environment.NewLine} {e.ToString()}");
                         throw e;
                     }
                     else


### PR DESCRIPTION
Defensive code first pass for connection error handling. Also sussed out a bug where it intercepted an invalid userId in the form of UserId|UserName (i.e. U82124|SamTwining) which choked the username lookup function.

Tested the connection error handling on a Win7 machine with no WebSocket support.

Handled the retry loop and then threw a descriptive error on failure:

![image](https://cloud.githubusercontent.com/assets/92731/23817751/8e545f20-05c3-11e7-9cff-45cddd400647.png)
