### PR TITLE
Add JsonExtensionData to message class to allow access to all message properies

### DIFF
--- a/lib/Bot.cs
+++ b/lib/Bot.cs
@@ -9,10 +9,8 @@ namespace Slackbot
         public string Text;
         public string Channel;
         public string[] MentionedUsers = new string[0];
+        public string RawMessage;
         public string User;
-        
-        [Newtonsoft.Json.JsonExtensionData]
-        public IDictionary<string, object> ExtensionData { get; } = new Dictionary<string, object>();
     }
 
     class SlackData
@@ -79,6 +77,8 @@ namespace Slackbot
                 }
 
                 args.User = await Slack.GetUsername(this.Token, args.User);
+
+                args.RawMessage = data;
 
                 OnMessage.Invoke(this, args);
             }


### PR DESCRIPTION
The `[JsonExtensionData]` attribute allows users to access json properties that weren't bound to .NET Properties, so extra things, e.g. `thread_ts` can be accessed.

Obviously a strong property is better, but this way you don't have to extend the lib whenever slack extend their api.