### PR TITLE
Added UserId property to retain the original user which allows adding…

### DIFF
--- a/lib/Bot.cs
+++ b/lib/Bot.cs
@@ -11,6 +11,7 @@ namespace Slackbot
         public string[] MentionedUsers = new string[0];
         public string RawMessage;
         public string User;
+        public string UserId;
     }
 
     class SlackData
@@ -67,6 +68,8 @@ namespace Slackbot
             if (ShouldParseSlackData(data))
             {
                 var args = Newtonsoft.Json.JsonConvert.DeserializeObject<OnMessageArgs>(data);
+
+                args.UserId = args.User; // Preserve original slack userid
 
                 args.MentionedUsers = SlackMessage.FindMentionedUsers(data);
 

--- a/lib/Slackbot.csproj
+++ b/lib/Slackbot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@mattcbaker I had to use @mentions in slack and slack only allows a format of <@userid> to do that hence, I added a Userid property in the model that let's me track the original id before it get's parsed into a name.